### PR TITLE
Add transformers setup script for fine-tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ streamlit run src/interface/app.py
 python src/sync_woocommerce.py
 ```
 
+### Préparer un jeu d'exemples pour le fine-tuning
+
+Un script utilitaire `scripts/setup_transformers_training.py` ajoute la dépendance
+`transformers` et crée un fichier `data/finetune_samples.jsonl` contenant quelques
+paires instruction/réponse.
+
+```bash
+python scripts/setup_transformers_training.py
+```
+
 ## 📱 Roadmap
 
 ### Phase 1 : Base ✅

--- a/data/finetune_samples.jsonl
+++ b/data/finetune_samples.jsonl
@@ -1,0 +1,3 @@
+{"instruction": "Quelle est la gamme de la bière Jonquille ?", "response": "La Jonquille appartient à la gamme clean et se présente toujours en canettes de 44cl."}
+{"instruction": "Combien de canettes comporte un carton ?", "response": "Un carton de canettes contient systématiquement 12 unités."}
+{"instruction": "Comment calculer le stock total ?", "response": "Additionnez les unités en stock et le nombre de cartons multiplié par 12 pour obtenir le stock total."}

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,3 +28,6 @@ requests==2.31.0
 aiohttp==3.9.1
 python-dateutil==2.8.2
 loguru==0.7.2
+
+# Machine Learning
+transformers==4.36.1

--- a/scripts/setup_transformers_training.py
+++ b/scripts/setup_transformers_training.py
@@ -1,0 +1,51 @@
+import json
+import os
+from pathlib import Path
+
+REQUIREMENTS_PATH = Path(__file__).resolve().parents[1] / "requirements.txt"
+DATASET_PATH = Path(__file__).resolve().parents[1] / "data" / "finetune_samples.jsonl"
+
+TRANSFORMERS_DEP = "transformers==4.36.1"
+
+
+def add_transformers_dependency(req_path=REQUIREMENTS_PATH):
+    if not req_path.exists():
+        print(f"{req_path} not found")
+        return
+    lines = req_path.read_text().splitlines()
+    if any(line.strip().startswith("transformers") for line in lines):
+        print("Transformers dependency already present")
+        return
+    with req_path.open("a", encoding="utf-8") as f:
+        if lines and lines[-1].strip() != "":
+            f.write("\n")
+        f.write("\n# Machine Learning\n" + TRANSFORMERS_DEP + "\n")
+    print("Added transformers to requirements.txt")
+
+
+def create_example_dataset(dataset_path=DATASET_PATH):
+    dataset_path.parent.mkdir(parents=True, exist_ok=True)
+    examples = [
+        {
+            "instruction": "Quelle est la gamme de la bière Jonquille ?",
+            "response": "La Jonquille appartient à la gamme clean et se présente toujours en canettes de 44cl."
+        },
+        {
+            "instruction": "Combien de canettes comporte un carton ?",
+            "response": "Un carton de canettes contient systématiquement 12 unités."
+        },
+        {
+            "instruction": "Comment calculer le stock total ?",
+            "response": "Additionnez les unités en stock et le nombre de cartons multiplié par 12 pour obtenir le stock total."
+        }
+    ]
+    with dataset_path.open("w", encoding="utf-8") as f:
+        for item in examples:
+            json.dump(item, f, ensure_ascii=False)
+            f.write("\n")
+    print(f"Wrote {len(examples)} examples to {dataset_path}")
+
+
+if __name__ == "__main__":
+    add_transformers_dependency()
+    create_example_dataset()


### PR DESCRIPTION
## Summary
- include `transformers` in requirements
- add sample `finetune_samples.jsonl` dataset
- provide script `setup_transformers_training.py` to create dataset and update `requirements.txt`
- document script usage in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install python-dotenv` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d65958b70832c85b2eb1b837f34c6